### PR TITLE
Add hierarchical category creation and reseller management

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -2,7 +2,7 @@ import sqlalchemy.exc
 import random
 import datetime
 from bot.database.models import User, ItemValues, Goods, Categories, BoughtGoods, \
-    Operations, UnfinishedOperations, PromoCode, UserAchievement, StockNotification
+    Operations, UnfinishedOperations, PromoCode, UserAchievement, StockNotification, Reseller, ResellerPrice
 from bot.database import Database
 
 
@@ -94,4 +94,10 @@ def grant_achievement(user_id: int, code: str, achieved_at: str) -> None:
 def add_stock_notification(user_id: int, item_name: str) -> None:
     session = Database().session
     session.add(StockNotification(user_id=user_id, item_name=item_name))
+    session.commit()
+
+
+def create_reseller(user_id: int) -> None:
+    session = Database().session
+    session.add(Reseller(user_id=user_id))
     session.commit()

--- a/bot/database/methods/delete.py
+++ b/bot/database/methods/delete.py
@@ -1,6 +1,6 @@
 import os
 from bot.utils.files import sanitize_name
-from bot.database.models import Database, Goods, ItemValues, Categories, UnfinishedOperations, PromoCode
+from bot.database.models import Database, Goods, ItemValues, Categories, UnfinishedOperations, PromoCode, Reseller, ResellerPrice
 
 
 def delete_item(item_name: str) -> None:
@@ -66,4 +66,11 @@ def buy_item(item_id: str, infinity: bool = False) -> None:
 def delete_promocode(code: str) -> None:
     session = Database().session
     session.query(PromoCode).filter(PromoCode.code == code).delete()
+    session.commit()
+
+
+def delete_reseller(user_id: int) -> None:
+    session = Database().session
+    session.query(ResellerPrice).filter(ResellerPrice.reseller_id == user_id).delete()
+    session.query(Reseller).filter(Reseller.user_id == user_id).delete()
     session.commit()

--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -7,6 +7,7 @@ from bot.database.models import (
     Categories,
     PromoCode,
     StockNotification,
+    ResellerPrice,
 )
 from bot.database import Database
 
@@ -85,6 +86,18 @@ def update_promocode(code: str, discount: int | None = None, expires_at: str | N
         return
     Database().session.query(PromoCode).filter(PromoCode.code == code).update(values=values)
     Database().session.commit()
+
+
+def set_reseller_price(reseller_id: int, item_name: str, price: int) -> None:
+    session = Database().session
+    entry = session.query(ResellerPrice).filter_by(
+        reseller_id=reseller_id, item_name=item_name
+    ).first()
+    if entry:
+        entry.price = price
+    else:
+        session.add(ResellerPrice(reseller_id=reseller_id, item_name=item_name, price=price))
+    session.commit()
 
 
 def clear_stock_notifications(item_name: str) -> None:

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -236,6 +236,27 @@ class PromoCode(Database.BASE):
         self.active = active
 
 
+class Reseller(Database.BASE):
+    __tablename__ = 'resellers'
+    user_id = Column(BigInteger, ForeignKey('users.telegram_id'), primary_key=True, unique=True)
+
+    def __init__(self, user_id: int):
+        self.user_id = user_id
+
+
+class ResellerPrice(Database.BASE):
+    __tablename__ = 'reseller_prices'
+    id = Column(Integer, primary_key=True)
+    reseller_id = Column(BigInteger, ForeignKey('resellers.user_id'), nullable=False)
+    item_name = Column(String(100), ForeignKey('goods.name'), nullable=False)
+    price = Column(BigInteger, nullable=False)
+
+    def __init__(self, reseller_id: int, item_name: str, price: int):
+        self.reseller_id = reseller_id
+        self.item_name = item_name
+        self.price = price
+
+
 class StockNotification(Database.BASE):
     __tablename__ = 'stock_notifications'
     id = Column(Integer, primary_key=True)

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -14,6 +14,7 @@ from bot.handlers.admin.assistant_management_states import register_assistant_ma
 from bot.handlers.admin.view_stock import register_view_stock
 from bot.handlers.admin.purchases import register_purchases
 from bot.handlers.admin.miscs import register_miscs
+from bot.handlers.admin.reseller_management_states import register_reseller_management
 from bot.handlers.other import get_bot_user_ids
 
 
@@ -74,4 +75,5 @@ def register_admin_handlers(dp: Dispatcher) -> None:
     register_assistant_management(dp)
     register_view_stock(dp)
     register_purchases(dp)
+    register_reseller_management(dp)
     register_miscs(dp)

--- a/bot/handlers/admin/reseller_management_states.py
+++ b/bot/handlers/admin/reseller_management_states.py
@@ -1,0 +1,294 @@
+from aiogram import Dispatcher
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+
+from bot.database.methods import (
+    check_role, check_user_by_username, create_reseller, delete_reseller,
+    get_resellers, set_reseller_price, get_all_category_names,
+    get_all_subcategories, get_all_item_names, get_category_parent,
+    check_user, is_reseller
+)
+from bot.database.models import Permission
+from bot.keyboards import back, resellers_management, resellers_list
+from bot.misc import TgConfig
+from bot.handlers.other import get_bot_user_ids
+from bot.utils import display_name
+
+
+async def resellers_management_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE):
+        await call.answer('Nepakanka teisių')
+        return
+    TgConfig.STATE[user_id] = None
+    await bot.edit_message_text('🤝 Resellerių meniu',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=resellers_management())
+
+
+async def reseller_add_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = 'reseller_add_username'
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    await bot.edit_message_text('Įveskite vartotojo vardą:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=back('resellers_management'))
+
+
+async def reseller_add_receive(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    if TgConfig.STATE.get(user_id) != 'reseller_add_username':
+        return
+    username = message.text.lstrip('@')
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    user = check_user_by_username(username)
+    if not user:
+        await bot.edit_message_text('❌ Vartotojas nerastas',
+                                    chat_id=message.chat.id,
+                                    message_id=message_id,
+                                    reply_markup=back('resellers_management'))
+        return
+    if is_reseller(user.telegram_id):
+        await bot.edit_message_text('⚠️ Vartotojas jau yra reselleris',
+                                    chat_id=message.chat.id,
+                                    message_id=message_id,
+                                    reply_markup=back('resellers_management'))
+        return
+    create_reseller(user.telegram_id)
+    TgConfig.STATE[user_id] = None
+    await bot.edit_message_text('✅ Reselleris pridėtas',
+                                chat_id=message.chat.id,
+                                message_id=message_id,
+                                reply_markup=back('resellers_management'))
+
+
+async def reseller_remove_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    res = get_resellers()
+    if not res:
+        await bot.edit_message_text('❌ Nėra resellerių',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back('resellers_management'))
+        return
+    await bot.edit_message_text('Pasirinkite resellerį:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=resellers_list(res, 'reseller_remove', 'resellers_management'))
+
+
+async def reseller_remove_select(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    rid = int(call.data[len('reseller_remove_'):])
+    user = check_user(rid)
+    markup = InlineKeyboardMarkup()
+    markup.add(InlineKeyboardButton('✅ Taip', callback_data=f'reseller_remove_confirm_{rid}'))
+    markup.add(InlineKeyboardButton('🔙 Ne', callback_data='reseller_remove'))
+    name = f'@{user.username}' if user and user.username else str(rid)
+    await bot.edit_message_text(f'Ar tikrai pašalinti {name}?',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def reseller_remove_confirm(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    rid = int(call.data[len('reseller_remove_confirm_'):])
+    delete_reseller(rid)
+    await bot.edit_message_text('✅ Reselleris pašalintas',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=back('resellers_management'))
+
+
+async def reseller_price_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    res = get_resellers()
+    if not res:
+        await bot.edit_message_text('❌ Nėra resellerių',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back('resellers_management'))
+        return
+    await bot.edit_message_text('Pasirinkite resellerį:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=resellers_list(res, 'reseller_price_res', 'resellers_management'))
+
+
+async def reseller_price_reseller(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    rid = int(call.data[len('reseller_price_res_'):])
+    TgConfig.STATE[f'{user_id}_reseller'] = rid
+    mains = get_all_category_names()
+    markup = InlineKeyboardMarkup()
+    for main in mains:
+        markup.add(InlineKeyboardButton(main, callback_data=f'reseller_price_main_{main}'))
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data='reseller_prices'))
+    await bot.edit_message_text('Pasirinkite pagrindinę kategoriją:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def reseller_price_main(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    main = call.data[len('reseller_price_main_'):]
+    rid = TgConfig.STATE.get(f'{user_id}_reseller')
+    categories = get_all_subcategories(main)
+    if categories:
+        markup = InlineKeyboardMarkup()
+        for cat in categories:
+            markup.add(InlineKeyboardButton(cat, callback_data=f'reseller_price_cat_{cat}'))
+        markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=f'reseller_price_res_{rid}'))
+        await bot.edit_message_text('Pasirinkite kategoriją:',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=markup)
+        return
+    items = get_all_item_names(main)
+    if not items:
+        await bot.edit_message_text('❌ Šioje kategorijoje nėra prekių',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back(f'reseller_price_res_{rid}'))
+        return
+    markup = InlineKeyboardMarkup()
+    for item in items:
+        markup.add(InlineKeyboardButton(display_name(item), callback_data=f'reseller_price_item_{item}'))
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=f'reseller_price_res_{rid}'))
+    await bot.edit_message_text('Pasirinkite prekę:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def reseller_price_cat(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    category = call.data[len('reseller_price_cat_'):]
+    rid = TgConfig.STATE.get(f'{user_id}_reseller')
+    subs = get_all_subcategories(category)
+    if subs:
+        markup = InlineKeyboardMarkup()
+        for sub in subs:
+            markup.add(InlineKeyboardButton(sub, callback_data=f'reseller_price_sub_{sub}'))
+        back_main = get_category_parent(category)
+        markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=f'reseller_price_main_{back_main}'))
+        await bot.edit_message_text('Pasirinkite subkategoriją:',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=markup)
+        return
+    items = get_all_item_names(category)
+    if not items:
+        back_main = get_category_parent(category)
+        await bot.edit_message_text('❌ Šioje kategorijoje nėra prekių',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back(f'reseller_price_main_{back_main}'))
+        return
+    markup = InlineKeyboardMarkup()
+    for item in items:
+        markup.add(InlineKeyboardButton(display_name(item), callback_data=f'reseller_price_item_{item}'))
+    back_main = get_category_parent(category)
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=f'reseller_price_main_{back_main}'))
+    await bot.edit_message_text('Pasirinkite prekę:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def reseller_price_sub(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    sub = call.data[len('reseller_price_sub_'):]
+    rid = TgConfig.STATE.get(f'{user_id}_reseller')
+    items = get_all_item_names(sub)
+    if not items:
+        parent = get_category_parent(sub)
+        await bot.edit_message_text('❌ Šioje kategorijoje nėra prekių',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back(f'reseller_price_cat_{parent}'))
+        return
+    markup = InlineKeyboardMarkup()
+    for item in items:
+        markup.add(InlineKeyboardButton(display_name(item), callback_data=f'reseller_price_item_{item}'))
+    parent = get_category_parent(sub)
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=f'reseller_price_cat_{parent}'))
+    await bot.edit_message_text('Pasirinkite prekę:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def reseller_price_item(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    item = call.data[len('reseller_price_item_'):]
+    rid = TgConfig.STATE.get(f'{user_id}_reseller')
+    TgConfig.STATE[user_id] = 'reseller_price_wait'
+    TgConfig.STATE[f'{user_id}_item'] = item
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    await bot.edit_message_text('Įveskite kainą:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=back(f'reseller_price_res_{rid}'))
+
+
+async def reseller_price_receive(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    if TgConfig.STATE.get(user_id) != 'reseller_price_wait':
+        return
+    price_text = message.text.strip()
+    rid = TgConfig.STATE.get(f'{user_id}_reseller')
+    item = TgConfig.STATE.get(f'{user_id}_item')
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    if not price_text.isdigit():
+        await bot.edit_message_text('⚠️ Neteisinga kaina',
+                                    chat_id=message.chat.id,
+                                    message_id=message_id,
+                                    reply_markup=back(f'reseller_price_res_{rid}'))
+        return
+    set_reseller_price(rid, item, int(price_text))
+    mains = get_all_category_names()
+    markup = InlineKeyboardMarkup()
+    for main in mains:
+        markup.add(InlineKeyboardButton(main, callback_data=f'reseller_price_main_{main}'))
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data='reseller_prices'))
+    TgConfig.STATE[user_id] = None
+    await bot.edit_message_text('✅ Kaina nustatyta. Pasirinkite pagrindinę kategoriją:',
+                                chat_id=message.chat.id,
+                                message_id=message_id,
+                                reply_markup=markup)
+
+
+def register_reseller_management(dp: Dispatcher) -> None:
+    dp.register_callback_query_handler(resellers_management_callback,
+                                       lambda c: c.data == 'resellers_management')
+    dp.register_callback_query_handler(reseller_add_callback,
+                                       lambda c: c.data == 'reseller_add')
+    dp.register_callback_query_handler(reseller_remove_callback,
+                                       lambda c: c.data == 'reseller_remove')
+    dp.register_callback_query_handler(reseller_remove_select,
+                                       lambda c: c.data.startswith('reseller_remove_') and not c.data.startswith('reseller_remove_confirm_'))
+    dp.register_callback_query_handler(reseller_remove_confirm,
+                                       lambda c: c.data.startswith('reseller_remove_confirm_'))
+    dp.register_callback_query_handler(reseller_price_callback,
+                                       lambda c: c.data == 'reseller_prices')
+    dp.register_callback_query_handler(reseller_price_reseller,
+                                       lambda c: c.data.startswith('reseller_price_res_'))
+    dp.register_callback_query_handler(reseller_price_main,
+                                       lambda c: c.data.startswith('reseller_price_main_'))
+    dp.register_callback_query_handler(reseller_price_cat,
+                                       lambda c: c.data.startswith('reseller_price_cat_'))
+    dp.register_callback_query_handler(reseller_price_sub,
+                                       lambda c: c.data.startswith('reseller_price_sub_'))
+    dp.register_callback_query_handler(reseller_price_item,
+                                       lambda c: c.data.startswith('reseller_price_item_'))
+    dp.register_message_handler(reseller_add_receive,
+                                lambda m: TgConfig.STATE.get(m.from_user.id) == 'reseller_add_username')
+    dp.register_message_handler(reseller_price_receive,
+                                lambda m: TgConfig.STATE.get(m.from_user.id) == 'reseller_price_wait')

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -382,11 +382,29 @@ async def assign_photos_callback_handler(call: CallbackQuery):
         await call.answer('Nepakanka teisių')
         return
     TgConfig.STATE[user_id] = None
-    categories = get_all_category_names()
+    mains = get_all_category_names()
+    markup = InlineKeyboardMarkup()
+    for main in mains:
+        markup.add(InlineKeyboardButton(main, callback_data=f'assign_photo_main_{main}'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='goods_management'))
+    await bot.edit_message_text('Choose main category:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def assign_photo_main_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        await call.answer('Nepakanka teisių')
+        return
+    main = call.data[len('assign_photo_main_'):]
+    categories = get_all_subcategories(main)
     markup = InlineKeyboardMarkup()
     for cat in categories:
         markup.add(InlineKeyboardButton(cat, callback_data=f'assign_photo_cat_{cat}'))
-    markup.add(InlineKeyboardButton('🔙 Back', callback_data='goods_management'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='assign_photos'))
     await bot.edit_message_text('Choose category:',
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id,
@@ -404,11 +422,10 @@ async def assign_photo_category_handler(call: CallbackQuery):
     markup = InlineKeyboardMarkup()
     for sub in subcats:
         markup.add(InlineKeyboardButton(sub, callback_data=f'assign_photo_sub_{sub}'))
-    items = get_all_item_names(category)
-    for item in items:
-        markup.add(InlineKeyboardButton(display_name(item), callback_data=f'assign_photo_item_{item}'))
-    markup.add(InlineKeyboardButton('🔙 Back', callback_data='assign_photos'))
-    await bot.edit_message_text('Choose subcategory or item:',
+    parent = get_category_parent(category)
+    back_data = 'assign_photos' if parent is None else f'assign_photo_main_{parent}'
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data=back_data))
+    await bot.edit_message_text('Choose subcategory:',
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id,
                                 reply_markup=markup)
@@ -425,7 +442,9 @@ async def assign_photo_subcategory_handler(call: CallbackQuery):
     markup = InlineKeyboardMarkup()
     for item in items:
         markup.add(InlineKeyboardButton(display_name(item), callback_data=f'assign_photo_item_{item}'))
-    markup.add(InlineKeyboardButton('🔙 Back', callback_data='assign_photos'))
+    parent = get_category_parent(sub)
+    back_data = f'assign_photo_cat_{parent}' if parent else 'assign_photos'
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data=back_data))
     await bot.edit_message_text('Choose item:',
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id,
@@ -470,8 +489,9 @@ async def assign_photo_receive_media(message: Message):
         return
     stock_path = get_next_file_path(item, ext)
     await file.download(destination_file=stock_path)
-    preview_path = os.path.join(preview_folder, os.path.basename(stock_path))
-    shutil.copy(stock_path, preview_path)
+    preview_file = os.path.join(preview_folder, f'preview.{ext}')
+    if not os.path.exists(preview_file):
+        shutil.copy(stock_path, preview_file)
     TgConfig.STATE[f'{user_id}_stock_path'] = stock_path
     TgConfig.STATE[user_id] = 'assign_photo_wait_desc'
     await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
@@ -581,13 +601,13 @@ async def categories_callback_handler(call: CallbackQuery):
     await call.answer('Nepakanka teisių')
 
 
-async def add_category_callback_handler(call: CallbackQuery):
+async def add_main_category_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
-    TgConfig.STATE[user_id] = 'add_category'
+    TgConfig.STATE[user_id] = 'add_main_category'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
     if role & Permission.SHOP_MANAGE:
-        await bot.edit_message_text('Enter category name',
+        await bot.edit_message_text('Enter main category name',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
                                     reply_markup=back("categories_management"))
@@ -595,17 +615,17 @@ async def add_category_callback_handler(call: CallbackQuery):
     await call.answer('Nepakanka teisių')
 
 
-async def add_subcategory_callback_handler(call: CallbackQuery):
+async def add_category_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
     if role & Permission.SHOP_MANAGE:
-        categories = get_all_category_names()
+        mains = get_all_category_names()
         markup = InlineKeyboardMarkup()
-        for cat in categories:
-            markup.add(InlineKeyboardButton(cat, callback_data=f'choose_sub_parent_{cat}'))
+        for main in mains:
+            markup.add(InlineKeyboardButton(main, callback_data=f'choose_cat_parent_{main}'))
         markup.add(InlineKeyboardButton('🔙 Back', callback_data='categories_management'))
-        await bot.edit_message_text('Select parent category:',
+        await bot.edit_message_text('Select main category:',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
                                     reply_markup=markup)
@@ -613,13 +633,65 @@ async def add_subcategory_callback_handler(call: CallbackQuery):
     await call.answer('Nepakanka teisių')
 
 
-async def choose_subcategory_parent(call: CallbackQuery):
+async def choose_category_parent(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
-    parent = call.data[len('choose_sub_parent_'):]
-    TgConfig.STATE[user_id] = 'add_subcategory_name'
+    parent = call.data[len('choose_cat_parent_'):]
+    TgConfig.STATE[user_id] = 'add_category_name'
     TgConfig.STATE[f'{user_id}_parent'] = parent
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
     if not check_category(parent):
+        await bot.edit_message_text(chat_id=call.message.chat.id,
+                                    message_id=message_id,
+                                    text='❌ Parent category does not exist',
+                                    reply_markup=back('categories_management'))
+        TgConfig.STATE[user_id] = None
+        return
+    await bot.edit_message_text(chat_id=call.message.chat.id,
+                                message_id=message_id,
+                                text='Enter category name',
+                                reply_markup=back('categories_management'))
+
+
+async def add_subcategory_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    role = check_role(user_id)
+    if role & Permission.SHOP_MANAGE:
+        mains = get_all_category_names()
+        markup = InlineKeyboardMarkup()
+        for main in mains:
+            markup.add(InlineKeyboardButton(main, callback_data=f'choose_sub_main_{main}'))
+        markup.add(InlineKeyboardButton('🔙 Back', callback_data='categories_management'))
+        await bot.edit_message_text('Select main category:',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=markup)
+        return
+    await call.answer('Nepakanka teisių')
+
+
+async def choose_subcategory_main(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    main = call.data[len('choose_sub_main_'):]
+    TgConfig.STATE[f'{user_id}_main'] = main
+    categories = get_all_subcategories(main)
+    markup = InlineKeyboardMarkup()
+    for cat in categories:
+        markup.add(InlineKeyboardButton(cat, callback_data=f'choose_sub_cat_{cat}'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='add_subcategory'))
+    await bot.edit_message_text('Select category:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def choose_subcategory_category(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    category = call.data[len('choose_sub_cat_'):]
+    TgConfig.STATE[user_id] = 'add_subcategory_name'
+    TgConfig.STATE[f'{user_id}_parent'] = category
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    if not check_category(category):
         await bot.edit_message_text(chat_id=call.message.chat.id,
                                     message_id=message_id,
                                     text='❌ Parent category does not exist',
@@ -665,7 +737,7 @@ async def statistics_callback_handler(call: CallbackQuery):
     await call.answer('Nepakanka teisių')
 
 
-async def process_category_for_add(message: Message):
+async def process_main_category_for_add(message: Message):
     bot, user_id = await get_bot_user_ids(message)
     msg = message.text
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
@@ -676,17 +748,40 @@ async def process_category_for_add(message: Message):
     if category:
         await bot.edit_message_text(chat_id=message.chat.id,
                                     message_id=message_id,
-                                    text='❌ Category not created (already exists)',
+                                    text='❌ Main category not created (already exists)',
                                     reply_markup=back('categories_management'))
         return
     create_category(msg)
+    await bot.edit_message_text(chat_id=message.chat.id,
+                                message_id=message_id,
+                                text='✅ Main category created',
+                                reply_markup=back('categories_management'))
+    admin_info = await bot.get_chat(user_id)
+    logger.info(f"User {user_id} ({admin_info.first_name}) "
+                f'created new main category "{msg}"')
+
+
+async def process_category_name(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    cat = message.text
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    parent = TgConfig.STATE.get(f'{user_id}_parent')
+    TgConfig.STATE[user_id] = None
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    if check_category(cat):
+        await bot.edit_message_text(chat_id=message.chat.id,
+                                    message_id=message_id,
+                                    text='❌ Category already exists',
+                                    reply_markup=back('categories_management'))
+        return
+    create_category(cat, parent)
     await bot.edit_message_text(chat_id=message.chat.id,
                                 message_id=message_id,
                                 text='✅ Category created',
                                 reply_markup=back('categories_management'))
     admin_info = await bot.get_chat(user_id)
     logger.info(f"User {user_id} ({admin_info.first_name}) "
-                f'created new category "{msg}"')
+                f'created category "{cat}" under "{parent}"')
 
 
 async def process_subcategory_name(message: Message):
@@ -906,24 +1001,70 @@ async def add_item_price(message: Message):
                                     reply_markup=back('item-management'))
         return
     TgConfig.STATE[f'{user_id}_price'] = message.text
-    categories = get_all_category_names()
+    TgConfig.STATE[user_id] = 'create_item_photo'
+    await bot.edit_message_text(chat_id=message.chat.id,
+                                message_id=message_id,
+                                text='Send preview photo for item:',
+                                reply_markup=back('item-management'))
+
+
+async def add_item_preview_photo(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    if TgConfig.STATE.get(user_id) != 'create_item_photo':
+        return
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    if not message.photo:
+        await bot.edit_message_text(chat_id=message.chat.id,
+                                    message_id=message_id,
+                                    text='❌ Send a photo',
+                                    reply_markup=back('item-management'))
+        return
+    file = message.photo[-1]
+    temp_folder = os.path.join('assets', 'temp_previews')
+    os.makedirs(temp_folder, exist_ok=True)
+    temp_path = os.path.join(temp_folder, f'{user_id}.jpg')
+    await file.download(destination_file=temp_path)
+    TgConfig.STATE[f'{user_id}_preview_path'] = temp_path
+    TgConfig.STATE[user_id] = None
+    mains = get_all_category_names()
     markup = InlineKeyboardMarkup()
-    for cat in categories:
-        markup.add(InlineKeyboardButton(cat, callback_data=f'add_item_cat_{cat}'))
+    for main in mains:
+        markup.add(InlineKeyboardButton(main, callback_data=f'add_item_main_{main}'))
     markup.add(InlineKeyboardButton('🔙 Back', callback_data='item-management'))
     await bot.edit_message_text(chat_id=message.chat.id,
                                 message_id=message_id,
-                                text='Select category:',
+                                text='Select main category:',
                                 reply_markup=markup)
 
 
 async def add_item_choose_category(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
-    categories = get_all_category_names()
+    mains = get_all_category_names()
+    markup = InlineKeyboardMarkup()
+    for main in mains:
+        markup.add(InlineKeyboardButton(main, callback_data=f'add_item_main_{main}'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='item-management'))
+    await bot.edit_message_text('Select main category:',
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                reply_markup=markup)
+
+
+async def add_item_main_selected(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    main = call.data[len('add_item_main_'):]
+    categories = get_all_subcategories(main)
+    if not categories:
+        await bot.edit_message_text('❌ No categories in this main category',
+                                    chat_id=call.message.chat.id,
+                                    message_id=call.message.message_id,
+                                    reply_markup=back('add_item_choose_cat'))
+        return
     markup = InlineKeyboardMarkup()
     for cat in categories:
         markup.add(InlineKeyboardButton(cat, callback_data=f'add_item_cat_{cat}'))
-    markup.add(InlineKeyboardButton('🔙 Back', callback_data='item-management'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='add_item_choose_cat'))
     await bot.edit_message_text('Select category:',
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id,
@@ -944,21 +1085,10 @@ async def add_item_category_selected(call: CallbackQuery):
                                     message_id=call.message.message_id,
                                     reply_markup=markup)
         return
-    item_name = TgConfig.STATE.get(f'{user_id}_name')
-    item_description = TgConfig.STATE.get(f'{user_id}_description')
-    item_price = TgConfig.STATE.get(f'{user_id}_price')
-    internal_name = generate_internal_name(item_name)
-    create_item(internal_name, item_description, item_price, category, None)
-    admin_info = await bot.get_chat(user_id)
-    logger.info(f"User {user_id} ({admin_info.first_name}) created new item \"{internal_name}\"")
-    markup = InlineKeyboardMarkup().add(
-        InlineKeyboardButton('✅ Yes', callback_data='add_item_more_yes'),
-        InlineKeyboardButton('❌ No', callback_data='add_item_more_no')
-    )
-    await bot.edit_message_text('Add this product somewhere else?',
+    await bot.edit_message_text('❌ No subcategories in this category',
                                 chat_id=call.message.chat.id,
                                 message_id=call.message.message_id,
-                                reply_markup=markup)
+                                reply_markup=back('add_item_choose_cat'))
 
 
 async def add_item_subcategory_selected(call: CallbackQuery):
@@ -968,6 +1098,12 @@ async def add_item_subcategory_selected(call: CallbackQuery):
     item_description = TgConfig.STATE.get(f'{user_id}_description')
     item_price = TgConfig.STATE.get(f'{user_id}_price')
     internal_name = generate_internal_name(item_name)
+    preview_src = TgConfig.STATE.get(f'{user_id}_preview_path')
+    preview_folder = os.path.join('assets', 'product_photos', internal_name)
+    os.makedirs(preview_folder, exist_ok=True)
+    if preview_src and os.path.isfile(preview_src):
+        ext = os.path.splitext(preview_src)[1]
+        shutil.copy(preview_src, os.path.join(preview_folder, f'preview{ext}'))
     create_item(internal_name, item_description, item_price, sub, None)
     admin_info = await bot.get_chat(user_id)
     logger.info(f"User {user_id} ({admin_info.first_name}) created new item \"{internal_name}\"")
@@ -990,6 +1126,9 @@ async def add_item_more_no(call: CallbackQuery):
     TgConfig.STATE[user_id] = None
     for key in ('name', 'description', 'price'):
         TgConfig.STATE.pop(f'{user_id}_{key}', None)
+    preview = TgConfig.STATE.pop(f'{user_id}_preview_path', None)
+    if preview and os.path.isfile(preview):
+        os.remove(preview)
     TgConfig.STATE.pop(f'{user_id}_message_id', None)
     await bot.edit_message_text('✅ Items created, products added',
                                 chat_id=call.message.chat.id,
@@ -1367,6 +1506,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                        lambda c: c.data == 'show_bought_item')
     dp.register_callback_query_handler(assign_photos_callback_handler,
                                        lambda c: c.data == 'assign_photos')
+    dp.register_callback_query_handler(assign_photo_main_handler,
+                                       lambda c: c.data.startswith('assign_photo_main_'))
     dp.register_callback_query_handler(assign_photo_category_handler,
                                        lambda c: c.data.startswith('assign_photo_cat_'))
     dp.register_callback_query_handler(assign_photo_subcategory_handler,
@@ -1385,12 +1526,20 @@ def register_shop_management(dp: Dispatcher) -> None:
                                        lambda c: c.data == 'promo_management')
     dp.register_callback_query_handler(categories_callback_handler,
                                        lambda c: c.data == 'categories_management')
+    dp.register_callback_query_handler(add_main_category_callback_handler,
+                                       lambda c: c.data == 'add_main_category')
     dp.register_callback_query_handler(add_category_callback_handler,
                                        lambda c: c.data == 'add_category')
     dp.register_callback_query_handler(add_subcategory_callback_handler,
                                        lambda c: c.data == 'add_subcategory')
-    dp.register_callback_query_handler(choose_subcategory_parent,
-                                       lambda c: c.data.startswith('choose_sub_parent_'))
+    dp.register_callback_query_handler(choose_category_parent,
+                                       lambda c: c.data.startswith('choose_cat_parent_'))
+    dp.register_callback_query_handler(choose_subcategory_main,
+                                       lambda c: c.data.startswith('choose_sub_main_'))
+    dp.register_callback_query_handler(choose_subcategory_category,
+                                       lambda c: c.data.startswith('choose_sub_cat_'))
+    dp.register_callback_query_handler(add_item_main_selected,
+                                       lambda c: c.data.startswith('add_item_main_'))
     dp.register_callback_query_handler(add_item_category_selected,
                                        lambda c: c.data.startswith('add_item_cat_'))
     dp.register_callback_query_handler(add_item_subcategory_selected,
@@ -1444,6 +1593,9 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'create_item_description')
     dp.register_message_handler(add_item_price,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'create_item_price')
+    dp.register_message_handler(add_item_preview_photo,
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'create_item_photo',
+                                content_types=['photo', 'text'])
     dp.register_message_handler(assign_photo_receive_media,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_media',
                                 content_types=['photo', 'video'])
@@ -1460,8 +1612,10 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'update_item_price')
     dp.register_message_handler(process_item_show,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'show_item')
-    dp.register_message_handler(process_category_for_add,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'add_category')
+    dp.register_message_handler(process_main_category_for_add,
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'add_main_category')
+    dp.register_message_handler(process_category_name,
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'add_category_name')
     dp.register_message_handler(process_subcategory_name,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'add_subcategory_name')
     dp.register_message_handler(check_category_for_update,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -329,6 +329,7 @@ def shop_management(role: int) -> InlineKeyboardMarkup:
         [InlineKeyboardButton('📦 Prekių įpakavimas', callback_data='goods_management')],
         [InlineKeyboardButton('🗂️ Kategorijų kūrimas', callback_data='categories_management')],
         [InlineKeyboardButton('🏷️ Nuolaidų kodai', callback_data='promo_management')],
+        [InlineKeyboardButton('🤝 Reselleriai', callback_data='resellers_management')],
         [InlineKeyboardButton('📢 Pranešimų siuntimas', callback_data='send_message')],
     ]
     if role & Permission.OWN:
@@ -442,6 +443,7 @@ def item_management() -> InlineKeyboardMarkup:
 
 def categories_management() -> InlineKeyboardMarkup:
     inline_keyboard = [
+        [InlineKeyboardButton('🗃️ Sukurti pagrindinę kategoriją', callback_data='add_main_category')],
         [InlineKeyboardButton('📁 Pridėti kategoriją', callback_data='add_category')],
         [InlineKeyboardButton('📂 Pridėti subkategoriją', callback_data='add_subcategory')],
         [InlineKeyboardButton('✏️ Atnaujinti kategoriją', callback_data='update_category')],
@@ -449,6 +451,25 @@ def categories_management() -> InlineKeyboardMarkup:
         [InlineKeyboardButton('🔙 Grįžti atgal', callback_data='shop_management')]
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def resellers_management() -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton('➕ Pridėti resellerį', callback_data='reseller_add')],
+        [InlineKeyboardButton('➖ Išimti resellerį', callback_data='reseller_remove')],
+        [InlineKeyboardButton('🏷️ Taikyti kainas', callback_data='reseller_prices')],
+        [InlineKeyboardButton('🔙 Grįžti atgal', callback_data='shop_management')],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def resellers_list(resellers: list[tuple[int, str | None]], action: str, back_data: str) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup()
+    for user_id, username in resellers:
+        name = f'@{username}' if username else str(user_id)
+        markup.add(InlineKeyboardButton(name, callback_data=f'{action}_{user_id}'))
+    markup.add(InlineKeyboardButton('🔙 Grįžti atgal', callback_data=back_data))
+    return markup
 
 
 def promo_codes_management() -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- Add "Sukurti pagrindinę kategoriją" button to categories management
- Support main categories, categories and subcategories in admin flows
- Require selecting main category → category → subcategory when creating products and assigning photos
- Ask admin for a preview image when creating a product and attach it for product selection
- Fix shop browsing to show categories that only contain items in deeper subcategories
- Show product's preview image instead of stock photo when viewing item details
- Preserve preview image when adding stock media
- Manage resellers with options to add, remove, and set per-reseller prices

## Testing
- `python -m py_compile bot/database/models/main.py bot/database/methods/create.py bot/database/methods/delete.py bot/database/methods/read.py bot/database/methods/update.py bot/keyboards/inline.py bot/handlers/admin/main.py bot/handlers/admin/reseller_management_states.py bot/handlers/user/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdeb93931c833282ea7bc0eff85614